### PR TITLE
Document Chrome Headless tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Karma Tests",
+            "url": "http://localhost:9876",
+            "webRoot": "${workspaceFolder}",
+            "runtimeArgs": ["--headless", "--disable-gpu"]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # student-management
-Student Management Website Using Angular, TypeScript, Django, PostgreSQL. In addition to TailwindCSS and Angular Material when needed.
+
+Student Management Website using Angular, TypeScript, Django, PostgreSQL. TailwindCSS and Angular Material are used when needed.
+
+## Testing
+Karma tests run using Chrome Headless.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,6 @@
+# Frontend
+
+This project uses Angular.
+
+## Testing
+Karma tests run using Chrome Headless.


### PR DESCRIPTION
## Summary
- document how Karma tests run in Chrome Headless
- add frontend README
- add VS Code launch config for headless Chrome

## Testing
- `grep -Ri "Edge" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_684027c85d588327b1978f645307a135