### PR TITLE
Update readme to mention Edge tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ python manage.py test
 
 **Frontend**
 
-The Angular project runs Karma tests in headless Chrome. Ensure Chrome is
+The Angular project runs Karma tests in headless Edge. Ensure Microsoft Edge is
 installed and run:
 
 ```bash
 npm test
-``` 
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -44,8 +44,8 @@ To execute unit tests with the [Karma](https://karma-runner.github.io) test runn
 ng test
 ```
 
-By default the configuration launches Chrome in headless mode. Ensure
-that the browser is installed on your system.
+By default the configuration launches Microsoft Edge in headless mode.
+Ensure that Edge is installed on your system.
 
 ## Running end-to-end tests
 


### PR DESCRIPTION
## Summary
- update root README instructions for Edge-based testing
- update frontend README and newlines

## Testing
- `python manage.py test`
- `npm test` *(fails: No binary for Edge browser)*

------
https://chatgpt.com/codex/tasks/task_e_68403d02b68c83279b28dfacb01641a4