### PR TITLE
Add Docker-based dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,29 @@ Student Management Website using Angular (TypeScript) for the frontend and Djang
 
 The project requires **Python 3.12+** and **Node.js 18+**. It's best to
 work inside a virtual environment when installing the backend
-dependencies:
+dependencies if you are running everything locally:
 
 ```bash
 python3 -m venv venv
 source venv/bin/activate
 ```
 
-### Backend
+### Docker Setup
+
+If you prefer running the backend inside Docker, make sure Docker is
+installed and then start the services using Docker Compose from the
+project root:
+
+```bash
+docker-compose up --build
+```
+
+The Django development server will be available on `http://localhost:8000`
+and will automatically apply migrations on start. A PostgreSQL instance is
+provided as part of the Compose setup.
+
+### Backend (local)
+If you are not using Docker, install dependencies and run the development server manually:
 
 ```
 cd backend
@@ -26,6 +41,10 @@ python manage.py runserver
 ```
 
 ### Frontend
+
+Ensure the backend is running (either locally or via Docker) on port
+`8000` before starting the Angular development server. The configuration
+in `proxy.conf.json` proxies `/api` requests to this backend server.
 
 1. Change into the `frontend` directory
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r backend/backend/requirements.txt
+CMD ["sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  backend:
+    build: ./backend
+    command: sh -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    volumes:
+      - ./backend:/app
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add Dockerfile for backend
- add docker-compose for backend/PostgreSQL
- document Docker-based workflow and updated frontend notes

## Testing
- `python manage.py test`
- `npm test` *(fails: No binary for Edge browser)*

------
https://chatgpt.com/codex/tasks/task_e_684051fbf060832796eda567ae7150fb